### PR TITLE
Hopefully fixed encoding and removed dedundant title reference

### DIFF
--- a/VIET_Immersion/PB/common/landed_titles/landed_titles.txt
+++ b/VIET_Immersion/PB/common/landed_titles/landed_titles.txt
@@ -53,7 +53,7 @@ k_papal_state = {
 		John Gregory Benedict Clement Innocent Leo Pius Stephen Boniface Urban Alexander Adrian Paul
 		Celestine Martin Nicholas Sixtus Felix Sergius Anastasius Honorius Eugene Sylvester Victor
 		Lucius Callixtus Julius Pelagius Adeodatus Theodore Marinus Agapetus Damasus Paschal
-		Gelasius Marcellus "Johnï¿½Paul" Anacletus Evaristus Telesphorus Hyginus Anicetus Mark Hilarius 
+		Gelasius Marcellus "John Paul" Anacletus Evaristus Telesphorus Hyginus Anicetus Mark Hilarius 
 		Simplicius Symmachus Hormisdas Silverius Vigilius Sabinian Severinus Vitalian Donus Agatho
 		Conon Sisinnius Constantine Zachary Valentine Formosus Romanus Lando
 	}
@@ -291,7 +291,7 @@ d_fraticelli = {
 		John Gregory Benedict Clement Innocent Leo Pius Stephen Boniface Urban Alexander Adrian Paul
 		Celestine Martin Nicholas Sixtus Felix Sergius Anastasius Honorius Eugene Sylvester Victor
 		Lucius Callixtus Julius Pelagius Adeodatus Theodore Marinus Agapetus Damasus Paschal
-		Gelasius Marcellus "Johnï¿½Paul" Anacletus Evaristus Telesphorus Hyginus Anicetus Mark Hilarius 
+		Gelasius Marcellus "John Paul" Anacletus Evaristus Telesphorus Hyginus Anicetus Mark Hilarius 
 		Simplicius Symmachus Hormisdas Silverius Vigilius Sabinian Severinus Vitalian Donus Agatho
 		Conon Sisinnius Constantine Zachary Valentine Formosus Romanus Lando
 	}
@@ -912,7 +912,7 @@ d_teutonic_order = {
 	
 	graphical_culture = holygfx
 	
-	capital = 258 # Lï¿½neburg
+	capital = 258 # Lüneburg
 
 	title = "HOCHMEISTER"
 	foa = "HOCHMEISTER_FOA"
@@ -2623,7 +2623,7 @@ d_finnish_band = {
 	color = { 131 35 35 }
 	color2 = { 255 255 255 }
 
-	capital = 383 # Hï¿½me
+	capital = 383 # Häme
 	
 	# Hire Trigger
 	allow = {
@@ -3110,7 +3110,7 @@ d_hanseatic_navy = { # Now "Baltic Cogs"
 	
 	short_name = yes
 
-	capital = 262 # Lï¿½beck
+	capital = 262 # Lübeck
 	
 	# Hire Trigger
 	allow = {
@@ -3641,10 +3641,10 @@ k_finland = {
 				finnish = "Nevanlinna"
 			}
 			b_noteborg = {
-				swedish = "Nï¿½teborg"
-				norwegian = "Nï¿½teborg"
-				danish = "Nï¿½teborg"
-				german = "Schlï¿½sselburg"
+				swedish = "Nöteborg"
+				norwegian = "Nøteborg"
+				danish = "Nøteborg"
+				german = "Schlüsselburg"
 				russian = "Oreshek"
 			}
 			b_valaam = {
@@ -3710,9 +3710,9 @@ k_finland = {
 			color={ 135 25 25 }
 			color2={ 255 255 255 }
 			
-			swedish = "ï¿½stkarelen"
-			danish = "ï¿½stkarelen"
-			norwegian = "ï¿½stkarelen"
+			swedish = "Östkarelen"
+			danish = "Østkarelen"
+			norwegian = "Østkarelen"
 			russian = "Kareliya"
 		
 			b_kem = {
@@ -3869,9 +3869,9 @@ k_finland = {
 			danish = "Nyland"
 		
 			b_porvoo = {
-				swedish = "Borgï¿½"
-				norwegian = "Borgï¿½"
-				danish = "Borgï¿½"
+				swedish = "Borgå"
+				norwegian = "Borgå"
+				danish = "Borgå"
 			}
 			b_raseborg = {
 				swedish = "Raseborg"
@@ -3884,14 +3884,14 @@ k_finland = {
 				danish = "Esbo"
 			}
 			b_siuntio = {
-				swedish = "Sjundeï¿½"
+				swedish = "Sjundeå"
 			}
 			b_svartholm = {
 			}
 			b_hanko = {
-				swedish = "Hangï¿½"
-				norwegian = "Hangï¿½"
-				danish = "Hangï¿½"
+				swedish = "Hangö"
+				norwegian = "Hangø"
+				danish = "Hangø"
 			}
 			b_lohja = {
 				swedish = "Lojo"
@@ -3910,19 +3910,19 @@ k_finland = {
 			danish = "Finland"
 		
 			b_kuusisto  = {
-				swedish = "Kustï¿½"
-				norwegian = "Kustï¿½"
-				danish = "Kustï¿½"
+				swedish = "Kustö"
+				norwegian = "Kustø"
+				danish = "Kustø"
 			}
 			b_turku  = {
-				swedish = "ï¿½bo"
-				norwegian = "ï¿½bo"
-				danish = "ï¿½bo"
+				swedish = "Åbo"
+				norwegian = "Åbo"
+				danish = "Åbo"
 			}
 			b_naantali = {
-				swedish = "Nï¿½dendal"
-				norwegian = "Nï¿½dendal"
-				danish = "Nï¿½dendal"
+				swedish = "Nådendal"
+				norwegian = "Nådendal"
+				danish = "Nådendal"
 			}
 			b_rikala  = {
 			}
@@ -3996,14 +3996,14 @@ k_finland = {
 			color={ 152 66 66 }
 			color2={ 255 255 255 }
 			
-			swedish = "ï¿½sterbotten"
-			norwegian = "ï¿½sterbotten"
-			danish = "ï¿½sterbotten"
+			swedish = "Österbotten"
+			norwegian = "Østerbotten"
+			danish = "Østerbotten"
 		
 			b_oulu = {
-				swedish = "Uleï¿½borg"
-				norwegian = "Uleï¿½borg"
-				danish = "Uleï¿½borg"
+				swedish = "Uleåborg"
+				norwegian = "Uleåborg"
+				danish = "Uleåborg"
 			}
 			b_nykarleby = {
 				swedish = "Nykarleby"
@@ -4558,7 +4558,7 @@ d_geats = {
 	
 	dignity = 8
 	
-	capital	= 297 # Vï¿½stergï¿½tland
+	capital	= 297 # Västergötland
 	
 	allow = {
 		always = no
@@ -5422,7 +5422,7 @@ e_latin_empire = {
 #		always = no
 #	}
 #	
-#	capital = 262 # Lï¿½beck
+#	capital = 262 # Lübeck
 #	
 #	dignity = 10
 #}
@@ -5431,7 +5431,7 @@ k_hansa = {
 	color={ 142 142 142 }
 	color2={ 255 255 255 }
 	
-	capital = 262 # Lï¿½beck
+	capital = 262 # Lübeck
 	
 	dignity = 200 # Never want the Hanseatic League to change primary title
 	
@@ -5569,7 +5569,7 @@ b_caetani = {
 	religion = catholic
 }
 
-# Lï¿½BECK:
+# LÜBECK:
 
 b_bardewik = {
 	culture = german
@@ -5658,11 +5658,6 @@ d_dyrrachion = {
 
 d_vidin = {
 	color={ 122 103 58 }
-	color2={ 255 255 255 }
-}
-
-d_jazira = {
-	color={ 95 180 35 }
 	color2={ 255 255 255 }
 }
 
@@ -5979,9 +5974,9 @@ d_mandaean = {
 	
 	# Regnal names
 	male_names = {
-		Abdu Abgar Abraham Amru Aram Aryu Bakru Bar-Abbï¿½ Bar-Navï¿½_Barnabas Bar-Tï¿½lmay Bar-Yï¿½ï¿½ Bar-ï¿½abbï¿½ 
-		Bnï¿½-ra'mï¿½ Daniel Ezad Fradhasht Gabriel Hairï¿½n Izates Ma'nu Maz'ur Monobaz Nasor Odainath_Odaenathus Paqor Sahru 
-		Semsoun Tabyï¿½ Tï¿½mï¿½ Wahballath Ya'il Yalur Yochanan Yohannon Yï¿½nï¿½ Zakkai
+		Abdu Abgar Abraham Amru Aram Aryu Bakru Bar-Abbâ Bar-Navâ_Barnabas Bar-Tôlmay Bar-Yêšû Bar-Šabbâ 
+		Bnê-ra'mâ Daniel Ezad Fradhasht Gabriel Hairân Izates Ma'nu Maz'ur Monobaz Nasor Odainath_Odaenathus Paqor Sahru 
+		Semsoun Tabyâ Tômâ Wahballath Ya'il Yalur Yochanan Yohannon Yônâ Zakkai
 	}
 }
 d_manichean_archegos = {


### PR DESCRIPTION
I lucked out with this file due to having the properly encoded versions of everything squirreled away, but the same can't be said for the others. There are at least two other landed_titles files which have broken encoding: viet_vanilla_titles.txt and landed_titles.txt and both them are in the VIET_Immersion/vanilla/common/landed_titles directory.
