### PR TITLE
Now obsolete _even_if_dead scope usages modernized

### DIFF
--- a/VIET_Events/events/VIET_on_actions_misc.txt
+++ b/VIET_Events/events/VIET_on_actions_misc.txt
@@ -418,7 +418,7 @@ character_event = {
 				}
 			}		#END brothers/sisters-in-law
 		}		#END brothers/sisters
-		father_even_if_dead = {		#father
+		father = {		#father
 			#opinion = {				#vanilla modifier used here
 			#	modifier = opinion_child
 			#	who = ROOT

--- a/VIET_Immersion/PB/decisions/minor_decisions.txt
+++ b/VIET_Immersion/PB/decisions/minor_decisions.txt
@@ -629,7 +629,7 @@ decisions = {
 			}
 			OR = {
 				primary_title = { higher_tier_than = COUNT }
-				father_even_if_dead = { primary_title = { higher_tier_than = COUNT } }
+				father = { primary_title = { higher_tier_than = COUNT } }
 			}
 			NOT = {	has_character_flag = commissioned_runestone }
 			NOT = { year = 1150 }

--- a/VIET_Immersion/common/common/minor_titles/ao_minor_titles.txt
+++ b/VIET_Immersion/common/common/minor_titles/ao_minor_titles.txt
@@ -10,7 +10,7 @@ title_favored_son={
 		dynasty = FROM
 		NOT = { trait = bastard }
 		is_child_of = FROM
-		father_even_if_dead = {is_alive = yes}
+		father = {is_alive = yes}
 		#NOT = {has_minor_title = title_favored_son}
 	}
 	gain_effect = {

--- a/VIET_Immersion/common/common/objectives/ao_ruler_ambitions.txt
+++ b/VIET_Immersion/common/common/objectives/ao_ruler_ambitions.txt
@@ -524,14 +524,14 @@ obj_noble_concubine = {
 						OR = { higher_tier_than = duke AND = { higher_tier_than = count independent = yes } }
 					}
 
-					father_even_if_dead = {
+					father = {
 						any_sibling = {
 							is_ruler = yes
 							OR = { higher_tier_than = duke AND = { higher_tier_than = count independent = yes } }
 						}
 					}
 
-					mother_even_if_dead = {
+					mother = {
 						any_sibling = {
 							is_ruler = yes
 							OR = { higher_tier_than = duke AND = { higher_tier_than = count independent = yes } }
@@ -558,14 +558,14 @@ obj_noble_concubine = {
 						OR = { higher_tier_than = duke AND = { higher_tier_than = count independent = yes } }
 					}
 
-					father_even_if_dead = {
+					father = {
 						any_sibling = {
 							is_ruler = yes
 							OR = { higher_tier_than = duke AND = { higher_tier_than = count independent = yes } }
 						}
 					}
 
-					mother_even_if_dead = {
+					mother = {
 						any_sibling = {
 							is_ruler = yes
 							OR = { higher_tier_than = duke AND = { higher_tier_than = count independent = yes } }
@@ -595,14 +595,14 @@ obj_noble_concubine = {
 					OR = { higher_tier_than = duke AND = { higher_tier_than = count independent = yes } }
 				}
 
-				father_even_if_dead = {
+				father = {
 					any_sibling = {
 						is_ruler = yes
 						OR = { higher_tier_than = duke AND = { higher_tier_than = count independent = yes } }
 					}
 				}
 
-				mother_even_if_dead = {
+				mother = {
 					any_sibling = {
 						is_ruler = yes
 						OR = { higher_tier_than = duke AND = { higher_tier_than = count independent = yes } }

--- a/VIET_Immersion/common/events/VIET_Celtic_flair.txt
+++ b/VIET_Immersion/common/events/VIET_Celtic_flair.txt
@@ -454,7 +454,7 @@ narrative_event = {
 			culture = norsebriton
 		}
 		higher_tier_than = COUNT
-		father_even_if_dead = {
+		father = {
 			is_alive = no
 		}
 		NOT = { has_character_flag = VIET_govan_stones_triggered }

--- a/VIET_Immersion/common/events/VIET_on_actions_misc.txt
+++ b/VIET_Immersion/common/events/VIET_on_actions_misc.txt
@@ -419,7 +419,7 @@ character_event = {
 				}
 			}		#END brothers/sisters-in-law
 		}		#END brothers/sisters
-		father_even_if_dead = {		#father
+		father = {		#father
 			#opinion = {				#vanilla modifier used here
 			#	modifier = opinion_child
 			#	who = ROOT

--- a/VIET_Immersion/common/events/adventures_the_old_gods.txt
+++ b/VIET_Immersion/common/events/adventures_the_old_gods.txt
@@ -709,24 +709,24 @@ character_event = {
 		}
 		
 		OR = {
-			father_even_if_dead = {
+			father = {
 				OR = {
 					primary_title = { higher_tier_than = BARON }
-					father_even_if_dead = {
+					father = {
 						primary_title = { higher_tier_than = BARON }
 					}
-					mother_even_if_dead = {
+					mother = {
 						primary_title = { higher_tier_than = BARON }
 					}
 				}
 			}
-			mother_even_if_dead = {
+			mother = {
 				OR = {
 					primary_title = { higher_tier_than = BARON }
-					father_even_if_dead = {
+					father = {
 						primary_title = { higher_tier_than = BARON }
 					}
-					mother_even_if_dead = {
+					mother = {
 						primary_title = { higher_tier_than = BARON }
 					}
 				}

--- a/VIET_Immersion/common/events/ao_fabbetrayal_events.txt
+++ b/VIET_Immersion/common/events/ao_fabbetrayal_events.txt
@@ -364,11 +364,11 @@ character_event = {
 			}
 			father = { if={limit = {is_ruler=yes NOT={has_character_flag=infbetrayalfail}} letter_event = {id = ao_fabbetrayal.13} set_character_flag = infbetrayalfail }}
 			mother = { if={limit = {is_ruler=yes NOT={has_character_flag=infbetrayalfail}} letter_event = {id = ao_fabbetrayal.13} set_character_flag = infbetrayalfail }}
-			father_even_if_dead = {
+			father = {
 				any_sibling = { limit = {is_ruler=yes NOT={has_character_flag=infbetrayalfail}} letter_event = {id = ao_fabbetrayal.13} set_character_flag = infbetrayalfail }
 				any_spouse = { limit = {is_ruler=yes NOT={has_character_flag=infbetrayalfail}} letter_event = {id = ao_fabbetrayal.13} set_character_flag = infbetrayalfail }
 			}
-			mother_even_if_dead = {
+			mother = {
 				any_sibling = { limit = {is_ruler=yes NOT={has_character_flag=infbetrayalfail}} letter_event = {id = ao_fabbetrayal.13} set_character_flag = infbetrayalfail }
 				any_spouse = { limit = {is_ruler=yes NOT={has_character_flag=infbetrayalfail}} letter_event = {id = ao_fabbetrayal.13} set_character_flag = infbetrayalfail }
 			}
@@ -411,11 +411,11 @@ character_event = {
 			}
 			father = { if={limit = {is_ruler=yes NOT={has_character_flag=infbetrayal}} letter_event = {id = ao_fabbetrayal.9} set_character_flag = infbetrayal }}
 			mother = { if={limit = {is_ruler=yes NOT={has_character_flag=infbetrayal}} letter_event = {id = ao_fabbetrayal.9} set_character_flag = infbetrayal }}
-			father_even_if_dead = {
+			father = {
 				any_sibling = { limit = {is_ruler=yes NOT={has_character_flag=infbetrayal}} letter_event = {id = ao_fabbetrayal.9} set_character_flag = infbetrayal }
 				any_spouse = { limit = {is_ruler=yes NOT={has_character_flag=infbetrayal}} letter_event = {id = ao_fabbetrayal.9} set_character_flag = infbetrayal }
 			}
-			mother_even_if_dead = {
+			mother = {
 				any_sibling = { limit = {is_ruler=yes NOT={has_character_flag=infbetrayal}} letter_event = {id = ao_fabbetrayal.9} set_character_flag = infbetrayal }
 				any_spouse = { limit = {is_ruler=yes NOT={has_character_flag=infbetrayal}} letter_event = {id = ao_fabbetrayal.9} set_character_flag = infbetrayal }
 			}

--- a/VIET_Immersion/common/events/jordarkelf_events.txt
+++ b/VIET_Immersion/common/events/jordarkelf_events.txt
@@ -109,7 +109,7 @@ character_event = {
 	trigger = {
 		is_ruler = no
 		NOT = { religion_group = jewish_group }
-		mother_even_if_dead = { religion_group = jewish_group }
+		mother = { religion_group = jewish_group }
 		NOT = { has_character_flag = no_more_jewish_event }
 	}
 	
@@ -121,7 +121,7 @@ character_event = {
 		name = jordarkelf.3.a
 		ai_chance = { factor = 100 }
 		set_character_flag = no_more_jewish_event
-		mother_even_if_dead = { 
+		mother = { 
 			reverse_religion = ROOT
 		}
 	}
@@ -148,7 +148,7 @@ character_event = {
 		NOT = { religion_group = jewish_group }
 		NOT = { has_character_flag = no_more_jewish_event }
 		OR = {
-			mother_even_if_dead = { religion_group = jewish_group }
+			mother = { religion_group = jewish_group }
 			NOT = { #only member of dynasty so probably a spawned Jew
 				any_dynasty_member = {
 					NOT = { character = ROOT }
@@ -167,9 +167,9 @@ character_event = {
 		set_character_flag = no_more_jewish_event
 		IF = { 
 			limit = { 
-				mother_even_if_dead = { religion_group = jewish_group }
+				mother = { religion_group = jewish_group }
 			}
-			mother_even_if_dead = {
+			mother = {
 				reverse_religion = ROOT
 			}
 		}

--- a/VIET_Immersion/common/events/soa_holy_order_events.txt
+++ b/VIET_Immersion/common/events/soa_holy_order_events.txt
@@ -463,10 +463,10 @@ character_event = {
 		is_title_active = d_knights_templar
 		
 		OR = {
-			father_even_if_dead = {
+			father = {
 				primary_title = { higher_tier_than = BARON }
 			}
-			mother_even_if_dead = {
+			mother = {
 				primary_title = { higher_tier_than = BARON }
 			}
 		}
@@ -1023,10 +1023,10 @@ character_event = {
 		is_title_active = d_knights_hospitaler
 		
 		OR = {
-			father_even_if_dead = {
+			father = {
 				primary_title = { higher_tier_than = BARON }
 			}
-			mother_even_if_dead = {
+			mother = {
 				primary_title = { higher_tier_than = BARON }
 			}
 		}
@@ -2069,10 +2069,10 @@ character_event = {
 		is_title_active = d_bektashi
 		
 		OR = {
-			father_even_if_dead = {
+			father = {
 				primary_title = { higher_tier_than = BARON }
 			}
-			mother_even_if_dead = {
+			mother = {
 				primary_title = { higher_tier_than = BARON }
 			}
 		}
@@ -2489,10 +2489,10 @@ character_event = {
 		is_title_active = d_teutonic_order
 		
 		OR = {
-			father_even_if_dead = {
+			father = {
 				primary_title = { higher_tier_than = BARON }
 			}
-			mother_even_if_dead = {
+			mother = {
 				primary_title = { higher_tier_than = BARON }
 			}
 		}
@@ -3336,10 +3336,10 @@ character_event = {
 		is_title_active = d_hashshashin
 		
 		OR = {
-			father_even_if_dead = {
+			father = {
 				primary_title = { higher_tier_than = BARON }
 			}
-			mother_even_if_dead = {
+			mother = {
 				primary_title = { higher_tier_than = BARON }
 			}
 		}
@@ -3813,10 +3813,10 @@ character_event = {
 		is_title_active = d_jomsvikings
 		
 		OR = {
-			father_even_if_dead = {
+			father = {
 				primary_title = { higher_tier_than = BARON }
 			}
-			mother_even_if_dead = {
+			mother = {
 				primary_title = { higher_tier_than = BARON }
 			}
 		}
@@ -4548,10 +4548,10 @@ character_event = {
 		is_title_active = d_holy_sepulchre
 		
 		OR = {
-			father_even_if_dead = {
+			father = {
 				primary_title = { higher_tier_than = BARON }
 			}
-			mother_even_if_dead = {
+			mother = {
 				primary_title = { higher_tier_than = BARON }
 			}
 		}
@@ -5259,10 +5259,10 @@ character_event = {
 		is_title_active = d_saint_anthony
 		
 		OR = {
-			father_even_if_dead = {
+			father = {
 				primary_title = { higher_tier_than = BARON }
 			}
-			mother_even_if_dead = {
+			mother = {
 				primary_title = { higher_tier_than = BARON }
 			}
 		}
@@ -5902,10 +5902,10 @@ character_event = {
 		is_title_active = d_immortals
 		
 		OR = {
-			father_even_if_dead = {
+			father = {
 				primary_title = { higher_tier_than = BARON }
 			}
-			mother_even_if_dead = {
+			mother = {
 				primary_title = { higher_tier_than = BARON }
 			}
 		}
@@ -6539,10 +6539,10 @@ character_event = {
 		is_title_active = d_zealots
 		
 		OR = {
-			father_even_if_dead = {
+			father = {
 				primary_title = { higher_tier_than = BARON }
 			}
-			mother_even_if_dead = {
+			mother = {
 				primary_title = { higher_tier_than = BARON }
 			}
 		}
@@ -7176,10 +7176,10 @@ character_event = {
 		is_title_active = d_sky_lords
 		
 		OR = {
-			father_even_if_dead = {
+			father = {
 				primary_title = { higher_tier_than = BARON }
 			}
-			mother_even_if_dead = {
+			mother = {
 				primary_title = { higher_tier_than = BARON }
 			}
 		}
@@ -7812,10 +7812,10 @@ character_event = {
 		is_title_active = d_spirit_guardians
 		
 		OR = {
-			father_even_if_dead = {
+			father = {
 				primary_title = { higher_tier_than = BARON }
 			}
-			mother_even_if_dead = {
+			mother = {
 				primary_title = { higher_tier_than = BARON }
 			}
 		}
@@ -8448,10 +8448,10 @@ character_event = {
 		is_title_active = d_warriors_perun
 		
 		OR = {
-			father_even_if_dead = {
+			father = {
 				primary_title = { higher_tier_than = BARON }
 			}
-			mother_even_if_dead = {
+			mother = {
 				primary_title = { higher_tier_than = BARON }
 			}
 		}
@@ -9084,10 +9084,10 @@ character_event = {
 		is_title_active = d_chosen_perkunas
 		
 		OR = {
-			father_even_if_dead = {
+			father = {
 				primary_title = { higher_tier_than = BARON }
 			}
-			mother_even_if_dead = {
+			mother = {
 				primary_title = { higher_tier_than = BARON }
 			}
 		}
@@ -9719,10 +9719,10 @@ character_event = {
 		is_title_active = d_sons_kaleva
 		
 		OR = {
-			father_even_if_dead = {
+			father = {
 				primary_title = { higher_tier_than = BARON }
 			}
-			mother_even_if_dead = {
+			mother = {
 				primary_title = { higher_tier_than = BARON }
 			}
 		}
@@ -10353,10 +10353,10 @@ character_event = {
 		is_title_active = d_huitzilopochtli
 		
 		OR = {
-			father_even_if_dead = {
+			father = {
 				primary_title = { higher_tier_than = BARON }
 			}
-			mother_even_if_dead = {
+			mother = {
 				primary_title = { higher_tier_than = BARON }
 			}
 		}
@@ -11024,10 +11024,10 @@ character_event = {
 		is_title_active = d_knights_santiago
 		
 		OR = {
-			father_even_if_dead = {
+			father = {
 				primary_title = { higher_tier_than = BARON }
 			}
-			mother_even_if_dead = {
+			mother = {
 				primary_title = { higher_tier_than = BARON }
 			}
 		}
@@ -11713,10 +11713,10 @@ character_event = {
 		is_title_active = d_knights_calatrava
 		
 		OR = {
-			father_even_if_dead = {
+			father = {
 				primary_title = { higher_tier_than = BARON }
 			}
-			mother_even_if_dead = {
+			mother = {
 				primary_title = { higher_tier_than = BARON }
 			}
 		}
@@ -12425,10 +12425,10 @@ character_event = {
 		is_title_active = d_saint_addai
 		
 		OR = {
-			father_even_if_dead = {
+			father = {
 				primary_title = { higher_tier_than = BARON }
 			}
-			mother_even_if_dead = {
+			mother = {
 				primary_title = { higher_tier_than = BARON }
 			}
 		}

--- a/VIET_Immersion/vanilla/decisions/minor_decisions.txt
+++ b/VIET_Immersion/vanilla/decisions/minor_decisions.txt
@@ -682,7 +682,7 @@ decisions = {
 			}
 			OR = {
 				primary_title = { higher_tier_than = COUNT }
-				father_even_if_dead = { primary_title = { higher_tier_than = COUNT } }
+				father = { primary_title = { higher_tier_than = COUNT } }
 			}
 			NOT = {	has_character_flag = commissioned_runestone }
 			NOT = { year = 1150 }


### PR DESCRIPTION
Only affects `mother_even_if_dead` and `father_even_if_dead`.  They mean the same thing as `mother` and `father`, properly implemented, but the scopes weren't properly implemented previously.  Further, the `_even_if_dead` versions have been deemed buggy at best, and Doomdark officially obsoleted them on the forums a few months ago, pre-RoI.
